### PR TITLE
Add disable_initial_exec_tls feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ stats = ["jemalloc-sys/stats"]
 background_threads_runtime_support = ["jemalloc-sys/background_threads_runtime_support"]
 background_threads = ["jemalloc-sys/background_threads"]
 unprefixed_malloc_on_supported_platforms = ["jemalloc-sys/unprefixed_malloc_on_supported_platforms"]
+disable_initial_exec_tls = ["jemalloc-sys/disable_initial_exec_tls"]
 
 [package.metadata.docs.rs]
 features = [ "alloc_trait" ]

--- a/jemalloc-sys/Cargo.toml
+++ b/jemalloc-sys/Cargo.toml
@@ -45,6 +45,7 @@ background_threads_runtime_support = []
 background_threads = [ "background_threads_runtime_support" ]
 stats = []
 unprefixed_malloc_on_supported_platforms = []
+disable_initial_exec_tls = []
 
 [package.metadata.docs.rs]
 rustdoc-args = [ "--cfg jemallocator_docs" ]

--- a/jemalloc-sys/README.md
+++ b/jemalloc-sys/README.md
@@ -76,6 +76,14 @@ This crate provides following cargo feature flags:
   libc. This usually causes C and C++ code linked in the same program to use
   `jemalloc` as well. On some platforms prefixes are always used because
   unprefixing is known to cause segfaults due to allocator mismatches.
+  
+* `disable_initial_exec_tls` (disabled by default): when enabled, jemalloc is
+  built with the `--disable-initial-exec-tls` option. It disables the 
+  initial-exec TLS model for jemalloc's internal thread-local storage (on those 
+  platforms that support explicit settings). This can allow jemalloc to be 
+  dynamically loaded after program startup (e.g. using dlopen). If you encounter
+  the error `yourlib.so: cannot allocate memory in static TLS block`, you'll 
+  likely want to enable this.
 
 ### Environment variables
 

--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -292,6 +292,11 @@ fn main() {
         cmd.arg("--enable-stats");
     }
 
+    if env::var("CARGO_FEATURE_DISABLE_INITIAL_EXEC_TLS").is_ok() {
+        info!("CARGO_FEATURE_DISABLE_INITIAL_EXEC_TLS set");
+        cmd.arg("--disable-initial-exec-tls");
+    }
+
     cmd.arg(format!("--host={}", gnu_target(&target)));
     cmd.arg(format!("--build={}", gnu_target(&host)));
     cmd.arg(format!("--prefix={}", out_dir.display()));


### PR DESCRIPTION
This feature allows libraries that link against jemalloc to be dlopened. This is useful when you want to e.g. build Python modules using PyO3 that still leverage the superior performance of jemalloc.

See

https://github.com/jemalloc/jemalloc/issues/937
https://github.com/jemalloc/jemalloc/blob/dev/INSTALL.md

for a detailed explanation of the feature.