### PR TITLE
jemalloc-ctl: impl std::error::Error for Error

### DIFF
--- a/jemalloc-ctl/src/error.rs
+++ b/jemalloc-ctl/src/error.rs
@@ -32,31 +32,58 @@ pub type Result<T> = result::Result<T, Error>;
 
 impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.0.get() as c_int {
-            libc::EINVAL => write!(
-                f,
-                "`newp` is not `NULL`, and `newlen` is too large or too \
-                 small. Alternatively, `*oldlenp` is too large or too \
-                 small; in this case as much data as possible are read \
-                 despite the error."
-            ),
-            libc::ENOENT => write!(
-                f,
-                "`name` or `mib` specifies an unknown/invalid value."
-            ),
-            libc::EPERM => write!(
-                f,
-                "Attempt to read or write `void` value, or attempt to \
-                 write read-only value."
-            ),
-            libc::EAGAIN => write!(f, "A memory allocation failure occurred."),
-            libc::EFAULT => write!(
-                f,
-                "An interface with side effects failed in some way not \
-                 directly related to `mallctl*()` read/write processing."
-            ),
-            v => write!(f, "Unknown error code: \"{}\".", v),
+        let code = self.0.get() as c_int;
+        match description(code) {
+            Some(m) => write!(f, "{}", m),
+            None => write!(f, "Unknown error code: \"{}\".", code),
         }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        <Self as fmt::Debug>::fmt(self, f)
+    }
+}
+
+#[cfg(feature = "use_std")]
+use std::error::Error as StdError;
+
+#[cfg(feature = "use_std")]
+impl StdError for Error {
+    fn description(&self) -> &str {
+        match description(self.0.get() as c_int) {
+            Some(m) => m,
+            None => "Unknown error"
+        }
+    }
+    fn cause(&self) -> Option<&dyn StdError> { None }
+    fn source(&self) -> Option<&(dyn StdError + 'static)> { None }
+}
+
+fn description(code: c_int) -> Option<&'static str> {
+    match code {
+        libc::EINVAL => Some(
+            "`newp` is not `NULL`, and `newlen` is too large or too \
+             small. Alternatively, `*oldlenp` is too large or too \
+             small; in this case as much data as possible are read \
+             despite the error."
+        ),
+        libc::ENOENT => Some(
+            "`name` or `mib` specifies an unknown/invalid value."
+        ),
+        libc::EPERM => Some(
+            "Attempt to read or write `void` value, or attempt to \
+             write read-only value."
+        ),
+        libc::EAGAIN => Some(
+            "A memory allocation failure occurred."
+        ),
+        libc::EFAULT => Some(
+            "An interface with side effects failed in some way not \
+             directly related to `mallctl*()` read/write processing."
+        ),
+        _ => None
     }
 }
 

--- a/jemalloc-ctl/src/error.rs
+++ b/jemalloc-ctl/src/error.rs
@@ -54,11 +54,15 @@ impl StdError for Error {
     fn description(&self) -> &str {
         match description(self.0.get() as c_int) {
             Some(m) => m,
-            None => "Unknown error"
+            None => "Unknown error",
         }
     }
-    fn cause(&self) -> Option<&dyn StdError> { None }
-    fn source(&self) -> Option<&(dyn StdError + 'static)> { None }
+    fn cause(&self) -> Option<&dyn StdError> {
+        None
+    }
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        None
+    }
 }
 
 fn description(code: c_int) -> Option<&'static str> {
@@ -67,23 +71,21 @@ fn description(code: c_int) -> Option<&'static str> {
             "`newp` is not `NULL`, and `newlen` is too large or too \
              small. Alternatively, `*oldlenp` is too large or too \
              small; in this case as much data as possible are read \
-             despite the error."
+             despite the error.",
         ),
-        libc::ENOENT => Some(
-            "`name` or `mib` specifies an unknown/invalid value."
-        ),
+        libc::ENOENT => {
+            Some("`name` or `mib` specifies an unknown/invalid value.")
+        }
         libc::EPERM => Some(
             "Attempt to read or write `void` value, or attempt to \
-             write read-only value."
+             write read-only value.",
         ),
-        libc::EAGAIN => Some(
-            "A memory allocation failure occurred."
-        ),
+        libc::EAGAIN => Some("A memory allocation failure occurred."),
         libc::EFAULT => Some(
             "An interface with side effects failed in some way not \
-             directly related to `mallctl*()` read/write processing."
+             directly related to `mallctl*()` read/write processing.",
         ),
-        _ => None
+        _ => None,
     }
 }
 


### PR DESCRIPTION
Only when "use_std". Extracts the string descriptions to share between Debug, Display, and StdError.