### PR TITLE
Fix wrong spelling of `unreachable unchecked`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ macro_rules! assume {
     ($e:expr) => {
         debug_assert!($e);
         if !($e) {
-            core::hint::unrachable_unchecked();
+            core::hint::unreachable_unchecked();
         }
     }
 }


### PR DESCRIPTION
This is why the CI for jemallocator is failing right now.

**Edit:** Or at least, it's why the build for the actual `jemallocator` crate fails in a context where you're using `JEMALLOC_OVERRIDE`, and **not** building `jemalloc` itself.