### PR TITLE
build.rs enhancements

### DIFF
--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -88,6 +88,7 @@ fn main() {
         use_prefix = true;
     }
 
+    // this has to occur before the early return when JEMALLOC_OVERRIDE is set
     if use_prefix {
         println!("cargo:rustc-cfg=prefixed");
     }
@@ -406,6 +407,7 @@ fn gnu_target(target: &str) -> String {
         "x86_64-pc-windows-msvc" => "x86_64-pc-win32".to_string(),
         "i686-pc-windows-gnu" => "i686-w64-mingw32".to_string(),
         "x86_64-pc-windows-gnu" => "x86_64-w64-mingw32".to_string(),
+        "armv7-linux-androideabi" => "arm-linux-androideabi".to_string(),
         s => s.to_string(),
     }
 }

--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -77,6 +77,21 @@ fn main() {
         warning!("jemalloc support for `{}` is untested", target);
     }
 
+    let mut use_prefix =
+        env::var("CARGO_FEATURE_UNPREFIXED_MALLOC_ON_SUPPORTED_PLATFORMS").is_err();
+
+    if !use_prefix && NO_UNPREFIXED_MALLOC.iter().any(|i| target.contains(i)) {
+        warning!(
+            "Unprefixed `malloc` requested on unsupported platform `{}` => using prefixed `malloc`",
+            target
+        );
+        use_prefix = true;
+    }
+
+    if use_prefix {
+        println!("cargo:rustc-cfg=prefixed");
+    }
+
     if let Some(jemalloc) = env::var_os("JEMALLOC_OVERRIDE") {
         info!("jemalloc override set");
         let jemalloc = PathBuf::from(jemalloc);
@@ -280,20 +295,8 @@ fn main() {
         cmd.arg(format!("--with-lg-vaddr={}", lg_vaddr));
     }
 
-    let mut use_prefix =
-        env::var("CARGO_FEATURE_UNPREFIXED_MALLOC_ON_SUPPORTED_PLATFORMS").is_err();
-
-    if !use_prefix && NO_UNPREFIXED_MALLOC.iter().any(|i| target.contains(i)) {
-        warning!(
-            "Unprefixed `malloc` requested on unsupported platform `{}` => using prefixed `malloc`",
-            target
-        );
-        use_prefix = true;
-    }
-
     if use_prefix {
         cmd.arg("--with-jemalloc-prefix=_rjem_");
-        println!("cargo:rustc-cfg=prefixed");
         info!("--with-jemalloc-prefix=_rjem_");
     }
 


### PR DESCRIPTION
1. Adapt android toolchain names
2. Use correct symbol prefix when using prebuilt jemalloc