### PR TITLE
Fix clang arm cross compile issue

### DIFF
--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -234,6 +234,13 @@ fn main() {
     .env("CPPFLAGS", cflags.clone())
     .arg("--disable-cxx");
 
+    // if the compiler is clang, add -E to run the preprocessor when configure checks it
+    if let Some(compiler_path) = compiler.path().to_str() {
+        if compiler_path.contains("clang") {
+            cmd.env("CPP", compiler_path.to_owned() + " -E");
+        }
+    }
+
     if target.contains("ios") {
         // newer iOS deviced have 16kb page sizes:
         // closed: https://github.com/gnzlbg/jemallocator/issues/68

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ macro_rules! assume {
         if !($e) {
             core::hint::unreachable_unchecked();
         }
-    }
+    };
 }
 
 /// Handle to the jemalloc allocator
@@ -122,7 +122,7 @@ unsafe impl GlobalAlloc for Jemalloc {
 
     #[inline]
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        assume!(!ptr.is_null())
+        assume!(!ptr.is_null());
         assume!(layout.size() != 0);
         let flags = layout_to_flags(layout.align(), layout.size());
         ffi::sdallocx(ptr as *mut c_void, layout.size(), flags)


### PR DESCRIPTION
When cross compiling for arm with clang, `configure` doesn't seem to add the `-E` flag when running clang when it checks the preprocessor. This results in "C preprocessor <path to clang> fails sanity check" and a failed build.