### PR TITLE
Configure jemalloc features properly

### DIFF
--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -303,24 +303,34 @@ fn main() {
 
     cmd.arg("--with-private-namespace=_rjem_");
 
+    // Always pass explicit --enable or --disable so changes in jemalloc
+    // defaults don't break us.
     if env::var("CARGO_FEATURE_DEBUG").is_ok() {
         info!("CARGO_FEATURE_DEBUG set");
         cmd.arg("--enable-debug");
+    } else {
+        cmd.arg("--disable-debug");
     }
 
     if env::var("CARGO_FEATURE_PROFILING").is_ok() {
         info!("CARGO_FEATURE_PROFILING set");
         cmd.arg("--enable-prof");
+    } else {
+        cmd.arg("--disable-prof");
     }
 
     if env::var("CARGO_FEATURE_STATS").is_ok() {
         info!("CARGO_FEATURE_STATS set");
         cmd.arg("--enable-stats");
+    } else {
+        cmd.arg("--disable-stats");
     }
 
     if env::var("CARGO_FEATURE_DISABLE_INITIAL_EXEC_TLS").is_ok() {
         info!("CARGO_FEATURE_DISABLE_INITIAL_EXEC_TLS set");
         cmd.arg("--disable-initial-exec-tls");
+    } else {
+        cmd.arg("--enable-initial-exec-tls");
     }
 
     cmd.arg(format!("--host={}", gnu_target(&target)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ unsafe impl GlobalAlloc for Jemalloc {
 
     #[inline]
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        assume!(!ptr.is_null())
+        assume!(!ptr.is_null());
         assume!(layout.size() != 0);
         let flags = layout_to_flags(layout.align(), layout.size());
         ffi::sdallocx(ptr as *mut c_void, layout.size(), flags)


### PR DESCRIPTION
Pass explicit --enable or --disable to the jemalloc configure.ac to avoid depending on jemalloc defaults (which could change).

Resolves #160