### PR TITLE
Make header available to C code

### DIFF
--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -364,6 +364,7 @@ fn main() {
         .arg(num_jobs.clone()));
 
     println!("cargo:root={}", out_dir.display());
+    println!("cargo:include={}/include", out_dir.display());
 
     // Linkage directives to pull in jemalloc and its dependencies.
     //


### PR DESCRIPTION
This makes the env variable `DEP_JEMALLOC_INCLUDE` available to the build script, where the include file for C code can be found.