### PR TITLE
Add missing semicolon

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ unsafe impl GlobalAlloc for Jemalloc {
 
     #[inline]
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        assume!(!ptr.is_null())
+        assume!(!ptr.is_null());
         assume!(layout.size() != 0);
         let flags = layout_to_flags(layout.align(), layout.size());
         ffi::sdallocx(ptr as *mut c_void, layout.size(), flags)


### PR DESCRIPTION
Hi all! We've been trying out bazel to build our Rust code, and jemallocator was the hardest to get to work, but as it turns out, this is the only code change I needed to get the whole thing working.

Hope you don't mind an extra semicolon!